### PR TITLE
[patch] Inherit options for multipart/form-data requests

### DIFF
--- a/lib/private/Parser/prototype.parseReq.js
+++ b/lib/private/Parser/prototype.parseReq.js
@@ -15,10 +15,13 @@ var Form = require('multiparty').Form;
 module.exports = function parseReq() {
   var self = this;
 
-
   // Save reference to `form` instance.
-  var form = this.form = new Form();
-
+  var form = this.form = new Form(
+  {
+  // Use skipper options (passed to body-parser for non-multipart requests)
+    maxFields: self.options.parameterLimit,
+    maxFieldsSize: self.options.limit
+  });;
 
 
   // Only one 'error' event should ever be emitted, and if an 'error' event


### PR DESCRIPTION
In case of multipart/form-data requests, skipper config (herited by body-parser for other types of requests) was not passed down when multiparty.Form is called.